### PR TITLE
fix: bump python-multipart + python-dotenv (medium CVEs)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 fastapi==0.115.11
 uvicorn[standard]==0.34.0
 pydantic==2.10.6
-python-dotenv==1.1.0
+python-dotenv==1.2.2
 tavily_python==0.5.1
-python-multipart==0.0.22
+python-multipart==0.0.26
 httpx==0.28.1
 ibm-watsonx-ai==1.3.6
 langgraph==1.0.10rc1


### PR DESCRIPTION
## Summary
Consolidates closed Dependabot PR #25 and adds python-dotenv:
- python-multipart 0.0.22 → 0.0.26 (DoS via large multipart preamble)
- python-dotenv 1.1.0 → 1.2.2 (symlink following)

Note: This is a separate PR from #23 (brace-expansion fix).